### PR TITLE
properly initialize the service name

### DIFF
--- a/ckanext/privatedatasets/plugin.py
+++ b/ckanext/privatedatasets/plugin.py
@@ -51,6 +51,7 @@ class PrivateDatasets(p.SingletonPlugin, tk.DefaultDatasetForm, DefaultPermissio
     ######################################################################
 
     def __init__(self, name=None):
+        self.name = name
         self.indexer = search.PackageSearchIndex()
 
     def _modify_package_schema(self,schema):


### PR DESCRIPTION
This issue caused the plugin to not be correctly ordered when iterating the plugin implementations of one of the interfaces it implements. As such, instead of being ordered as in the config file it used to be added last to the list of implementations.